### PR TITLE
socket: handle EMFILE during accept and cgi refactoring

### DIFF
--- a/include/http/HttpRequest.hpp
+++ b/include/http/HttpRequest.hpp
@@ -44,7 +44,7 @@ class HttpRequest {
     const std::string&                        getBody(void) const;
     std::size_t                               getContentLength(void) const;
     /* const std::string& getUri(void) const; */ const std::string& getQuery() const;
-    int getParseErrorCode(void) const;
+    int                                                             getParseErrorCode(void) const;
 
     void setMethod(const std::string& method);
     void setPath(const std::string& path);

--- a/include/http/handleCgi.hpp
+++ b/include/http/handleCgi.hpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 00:24:43 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/03 13:25:03 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 15:17:53 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,8 +35,9 @@ struct CgiProcess {
 
 namespace CGI {
 
+void         unlinkWithErrorLog(const std::string& path, const std::string& context);
 bool         initCgiProcess(CgiProcess& cgi, const HttpRequest& request, const Server& server,
-                            const Location& loc, const std::vector<pollfd>& poll_fds);
+                            const Location& loc, const std::vector<pollfd>& poll_fds, int& errorCode);
 HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpRequest& request);
 void         cleanupCgi(CgiProcess& cgi);
 void         errorOnCgi(CgiProcess& cgi);

--- a/include/http/handleCgi.hpp
+++ b/include/http/handleCgi.hpp
@@ -6,22 +6,22 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 00:24:43 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/05 15:17:53 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:22:10 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
-#include "core/Location.hpp"
-#include "core/Server.hpp"
-#include "http/HttpRequest.hpp"
-#include "http/HttpResponse.hpp"
+#include "http/HttpResponse.hpp" // for HttpResponse
+#include <string>                // for string
+#include <time.h>                // for time_t
+#include <unistd.h>              // for pid_t
+#include <vector>                // for vector
 
-#include <optional>
-#include <poll.h>
-#include <string>
-#include <unistd.h>
-#include <vector>
+class HttpRequest;
+class Location;
+class Server;
+struct pollfd;
 
 struct CgiProcess {
     pid_t       pid           = -1;

--- a/include/network/SocketManager.hpp
+++ b/include/network/SocketManager.hpp
@@ -6,27 +6,26 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:47 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/05 00:29:11 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:27:20 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
-#include "core/Server.hpp"
-#include "http/HttpResponse.hpp"
-#include "http/handleCgi.hpp"
-#include <arpa/inet.h>
-#include <cstring>
-#include <fcntl.h>
-#include <fstream>
-#include <iostream>
-#include <map>
-#include <optional>
-#include <poll.h>
-#include <queue>
-#include <signal.h>
-#include <unistd.h>
-#include <vector>
+#include "core/Server.hpp"       // for Server
+#include "http/HttpRequest.hpp"  // for HttpRequest
+#include "http/HttpResponse.hpp" // for HttpResponse
+#include "http/handleCgi.hpp"    // for CgiProcess
+#include <exception>             // for exception
+#include <fstream>               // for basic_ifstream, ifstream
+#include <map>                   // for map
+#include <optional>              // for optional
+#include <poll.h>                // for pollfd
+#include <queue>                 // for queue
+#include <signal.h>              // for size_t
+#include <string>                // for string
+#include <time.h>                // for time_t
+#include <vector>                // for vector
 
 #define TIMEOUT 20
 #define HEADER_TIMEOUT_SECONDS 6
@@ -35,6 +34,8 @@
 #define RECV_BUFFER HEADER_MAX_LENGTH * 2
 #define MAX_CLIENTS 1024
 #define CGI_TIMEOUT_SECONDS 45
+
+class Location;
 
 struct ClientInfo {
     int                       client_fd;       // File descriptor of the client socket

--- a/include/utils/filesystemUtils.hpp
+++ b/include/utils/filesystemUtils.hpp
@@ -6,22 +6,18 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/13 09:38:32 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/06 12:44:52 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:35:04 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #pragma once
 
-#include "core/Location.hpp"
-#include "core/Server.hpp"
-#include "http/HttpRequest.hpp"
-#include "http/HttpResponse.hpp"
-#include <cstring>
-#include <filesystem>
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <sys/stat.h>
+#include "http/HttpResponse.hpp" // for HttpResponse
+#include <string>                // for string, allocator
+#include <time.h>                // for time_t
+
+class HttpRequest;
+class Location;
 
 std::string  make_temp_name(const std::string& prefix, unsigned& counter);
 bool         isFile(const std::string& path);

--- a/include/utils/filesystemUtils.hpp
+++ b/include/utils/filesystemUtils.hpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/13 09:38:32 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/03 17:26:40 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 12:44:52 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ std::string  buildFilePath(const HttpRequest& request, const Location& loc);
 bool         mkdirRecursive(const std::string& path);
 std::string  decodePercentEncoding(const std::string& encoded);
 bool         isSymlink(const std::string& path);
+time_t       getCurrentTime();
 
 /* bool isInvalidAbsolutePath(const std::string& pathStr);
 bool isSuspiciousFilename(const std::string& pathStr); */

--- a/notes/Includes.md
+++ b/notes/Includes.md
@@ -1,0 +1,95 @@
+
+### ✅ **1. Use Include-What-You-Use (IWYU) Tool**
+
+**[IWYU](https://github.com/include-what-you-use/include-what-you-use)** is a Clang-based tool that:
+
+* Tells you which headers are **not needed** and can be removed.
+* Suggests what **should be included** instead (e.g. including `<vector>` if you use `std::vector` but only include `<iostream>`).
+
+#### 🔧 How to install (Ubuntu/macOS):
+
+```bash
+sudo apt install iwyu       # On Ubuntu/Debian
+brew install iwyu           # On macOS (requires Homebrew)
+```
+
+#### ⚙️ How to run:
+
+If you're using `clang++`:
+
+```bash
+iwyu -std=c++20 -I. your_file.cpp
+```
+
+If you use `g++` normally, just tell IWYU to mimic its behavior:
+
+```bash
+iwyu -std=c++20 -I. -x c++ -include your_project_prefix.hpp your_file.cpp
+```
+
+> 🔁 You may need to pass additional `-I` flags to include project headers.
+
+---
+
+### ✅ **2. Use CMake Integration (if you use CMake)**
+
+You can automate IWYU across your entire project by adding this to your `CMakeLists.txt`:
+
+```cmake
+set(CMAKE_CXX_INCLUDE_WHAT_YOU_USE iwyu)
+```
+
+Or for a single target:
+
+```cmake
+set_property(TARGET my_target PROPERTY CXX_INCLUDE_WHAT_YOU_USE iwyu)
+```
+
+---
+
+### ✅ **3. Clang-Tidy (alternative or complementary)**
+
+[`clang-tidy`](https://clang.llvm.org/extra/clang-tidy/) can also identify unused includes with checks like `llvm-include-order` and `modernize-deprecated-headers`.
+
+Example:
+
+```bash
+clang-tidy your_file.cpp -checks='-*,llvm-include-order' -- -std=c++20 -I.
+```
+
+---
+
+### ✅ **4. Manual Static Analysis with Compiler Flags**
+
+If you're restricted to standard tools, try enabling stricter warnings that help catch header-related issues:
+
+```bash
+g++ -Wall -Wextra -Wpedantic -Wmissing-include-dirs -std=c++20 ...
+```
+
+These won't detect *unused* includes directly, but they’ll help you avoid missing ones.
+
+---
+
+### ✅ **5. IDE Assistance**
+
+If you use **Visual Studio Code**, **CLion**, or **Visual Studio**:
+
+* Many IDEs will gray out unused includes.
+* Some can suggest removal or provide include hierarchy.
+
+CLion, for example, has a “Optimize Imports” feature.
+
+---
+
+### Summary
+
+| Tool       | Purpose                                |
+| ---------- | -------------------------------------- |
+| IWYU       | Most accurate, specific to includes    |
+| Clang-Tidy | Broader checks, style + usage          |
+| CMake      | Can integrate IWYU automatically       |
+| Compiler   | Use warnings to catch missing includes |
+| IDE        | Can assist interactively               |
+
+---

--- a/src/http/HttpRequest.cpp
+++ b/src/http/HttpRequest.cpp
@@ -127,9 +127,9 @@ bool HttpRequest::hasHeader(const std::string& key) const {
 }
 
 void HttpRequest::setParseErrorCode(int error) {
-	_parseError = error;
+    _parseError = error;
 }
 
 int HttpRequest::getParseErrorCode(void) const {
-	return _parseError;
+    return _parseError;
 }

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,24 +6,34 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/06 13:07:40 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:25:12 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "http/handleCgi.hpp"
-#include "http/HttpResponseBuilder.hpp"
-#include "utils/Logger.hpp"
-#include "utils/filesystemUtils.hpp"
-#include "utils/stringUtils.hpp"
-#include <fcntl.h>
-#include <filesystem>
-#include <fstream>
-#include <poll.h>
-#include <signal.h>
-#include <sstream>
-#include <sys/wait.h>
-#include <unistd.h>
-#include <vector>
+#include "core/Location.hpp"            // for Location
+#include "core/Server.hpp"              // for Server
+#include "http/HttpRequest.hpp"         // for HttpRequest
+#include "http/HttpResponseBuilder.hpp" // for generateError, generateSucce...
+#include "utils/Logger.hpp"             // for LogLevel, Logger
+#include "utils/filesystemUtils.hpp"    // for getCurrentTime, make_temp_name
+#include "utils/stringUtils.hpp"        // for trim, toUpper
+#include <algorithm>                    // for replace
+#include <errno.h>                      // for errno
+#include <fcntl.h>                      // for open, O_CREAT, O_RDONLY, O_RDWR
+#include <filesystem>                   // for path, absolute
+#include <fstream>                      // for basic_ifstream, basic_istream
+#include <map>                          // for map, operator==, _Rb_tree_co...
+#include <optional>                     // for optional, nullopt
+#include <poll.h>                       // for pollfd
+#include <signal.h>                     // for kill, SIGKILL
+#include <sstream>                      // for basic_istringstream
+#include <stdlib.h>                     // for exit
+#include <string.h>                     // for strerror
+#include <sys/wait.h>                   // for waitpid, WNOHANG
+#include <unistd.h>                     // for close, size_t, dup2, STDIN_F...
+#include <utility>                      // for pair
+#include <vector>                       // for vector
 
 namespace {
 
@@ -96,14 +106,14 @@ std::pair<std::string, std::streamsize> readInitialOutput(std::ifstream& file, s
     std::vector<char> buffer(maxBytes);
     file.read(buffer.data(), maxBytes);
     std::streamsize bytesRead = file.gcount();
-    return { std::string(buffer.data(), bytesRead), bytesRead };
+    return {std::string(buffer.data(), bytesRead), bytesRead};
 }
 
 std::optional<size_t> findHeaderDelimiter(const std::string& data, size_t& delimiterLength) {
-    size_t pos = data.find("\r\n\r\n");
+    size_t pos      = data.find("\r\n\r\n");
     delimiterLength = 4;
     if (pos == std::string::npos) {
-        pos = data.find("\n\n");
+        pos             = data.find("\n\n");
         delimiterLength = 2;
     }
     if (pos != std::string::npos) {
@@ -114,8 +124,8 @@ std::optional<size_t> findHeaderDelimiter(const std::string& data, size_t& delim
 
 std::pair<int, std::string> parseHeaders(const std::string& header) {
     std::istringstream stream(header);
-    std::string line, contentType = "";
-    int statusCode = 200;
+    std::string        line, contentType = "";
+    int                statusCode = 200;
 
     while (std::getline(stream, line)) {
         if (line.find("Content-Type:") == 0)
@@ -129,7 +139,7 @@ std::pair<int, std::string> parseHeaders(const std::string& header) {
             }
         }
     }
-    return { statusCode, contentType };
+    return {statusCode, contentType};
 }
 
 bool validateCgiScript(const std::filesystem::path& path, int& errorCode) {
@@ -148,8 +158,8 @@ bool validateCgiScript(const std::filesystem::path& path, int& errorCode) {
 
 bool prepareCgiTempFiles(CgiProcess& cgi, const HttpRequest& req, int& bodyFd, int& outputFd) {
     static unsigned counter = 0;
-    cgi.input_path  = make_temp_name("webserv_in", counter);
-    cgi.output_path = make_temp_name("webserv_out", counter);
+    cgi.input_path          = make_temp_name("webserv_in", counter);
+    cgi.output_path         = make_temp_name("webserv_out", counter);
 
     std::ofstream out(cgi.input_path, std::ios::binary);
     if (!out.is_open()) {
@@ -175,72 +185,63 @@ bool prepareCgiTempFiles(CgiProcess& cgi, const HttpRequest& req, int& bodyFd, i
     return true;
 }
 
-void setupAndRunCgiChild(
-    const CgiProcess& cgi,
-    int body_fd,
-    int output_fd,
-    const HttpRequest& req,
-    const Server& server,
-    const Location& loc,
-    const std::vector<pollfd>& poll_fds)
-{
+void setupAndRunCgiChild(const CgiProcess& cgi, int body_fd, int output_fd, const HttpRequest& req,
+                         const Server& server, const Location& loc,
+                         const std::vector<pollfd>& poll_fds) {
     if (dup2(body_fd, STDIN_FILENO) == -1) {
-            Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
-                            "dup2 stdin failed: " + std::string(strerror(errno)));
-            exit(1);
-        }
-        close(body_fd);
-        if (dup2(output_fd, STDOUT_FILENO) == -1) {
-            Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
-                            "dup2 stdout failed: " + std::string(strerror(errno)));
-            exit(1);
-        }
-        close(output_fd);
-        for (std::vector<pollfd>::const_iterator it = poll_fds.begin(); it != poll_fds.end();
-             ++it) {
-            int fd = it->fd;
-            if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO) {
-                close(fd);
-            }
-        }
-
-        // 1. Store script and interpreter in scoped std::string
-        std::string scriptPath = cgi.script_path;
-        std::string ext        = std::filesystem::path(scriptPath).extension().string();
-        std::string interp     = loc.getCgiInterpreter(ext);
-
-        // 2. Build argv using references to scoped strings
-        std::vector<std::string> argvStorage;
-        if (!interp.empty()) {
-            argvStorage.push_back(interp);
-        }
-        argvStorage.push_back(scriptPath);
-
-        std::vector<char*> argv;
-        for (size_t i = 0; i < argvStorage.size(); ++i) {
-            argv.push_back(const_cast<char*>(argvStorage[i].c_str()));
-        }
-        argv.push_back(nullptr);
-
-        // 3. Environment: same principle
-        std::vector<std::string> envStrs = prepareEnv(req, server, loc, scriptPath);
-        std::vector<char*>       envp    = toCharPtrArray(envStrs);
-
-        // 4. chdir safely
-        const std::string cgiDir = std::filesystem::path(scriptPath).parent_path().string();
-        if (chdir(cgiDir.c_str()) != 0) {
-            Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
-                            "chdir failed: " + std::string(strerror(errno)));
-            exit(1);
-        }
-        execve(argv[0], argv.data(), envp.data());
-
-        // 5. If execve fails
         Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
-                        "execve failed: " + std::string(strerror(errno)));
+                        "dup2 stdin failed: " + std::string(strerror(errno)));
         exit(1);
-}
+    }
+    close(body_fd);
+    if (dup2(output_fd, STDOUT_FILENO) == -1) {
+        Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
+                        "dup2 stdout failed: " + std::string(strerror(errno)));
+        exit(1);
+    }
+    close(output_fd);
+    for (std::vector<pollfd>::const_iterator it = poll_fds.begin(); it != poll_fds.end(); ++it) {
+        int fd = it->fd;
+        if (fd != STDIN_FILENO && fd != STDOUT_FILENO && fd != STDERR_FILENO) {
+            close(fd);
+        }
+    }
 
+    // 1. Store script and interpreter in scoped std::string
+    std::string scriptPath = cgi.script_path;
+    std::string ext        = std::filesystem::path(scriptPath).extension().string();
+    std::string interp     = loc.getCgiInterpreter(ext);
+
+    // 2. Build argv using references to scoped strings
+    std::vector<std::string> argvStorage;
+    if (!interp.empty()) {
+        argvStorage.push_back(interp);
+    }
+    argvStorage.push_back(scriptPath);
+
+    std::vector<char*> argv;
+    for (size_t i = 0; i < argvStorage.size(); ++i) {
+        argv.push_back(const_cast<char*>(argvStorage[i].c_str()));
+    }
+    argv.push_back(nullptr);
+
+    // 3. Environment: same principle
+    std::vector<std::string> envStrs = prepareEnv(req, server, loc, scriptPath);
+    std::vector<char*>       envp    = toCharPtrArray(envStrs);
+
+    // 4. chdir safely
+    const std::string cgiDir = std::filesystem::path(scriptPath).parent_path().string();
+    if (chdir(cgiDir.c_str()) != 0) {
+        Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
+                        "chdir failed: " + std::string(strerror(errno)));
+        exit(1);
+    }
+    execve(argv[0], argv.data(), envp.data());
+
+    // 5. If execve fails
+    Logger::logFrom(LogLevel::ERROR, "CGI CHILD", "execve failed: " + std::string(strerror(errno)));
+    exit(1);
+}
 
 } // namespace
 
@@ -302,17 +303,17 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
 
     // Read the first 9KB only to find headers
     constexpr size_t MAX_HEADER_SCAN = 9 * 1024;
-    auto [initialData, bytesRead] = readInitialOutput(in, MAX_HEADER_SCAN);
-    size_t delimLen = 0;
-    auto headerEndOpt = findHeaderDelimiter(initialData, delimLen);
+    auto [initialData, bytesRead]    = readInitialOutput(in, MAX_HEADER_SCAN);
+    size_t delimLen                  = 0;
+    auto   headerEndOpt              = findHeaderDelimiter(initialData, delimLen);
     if (!headerEndOpt) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "Header delimiter not found in first 9KB");
         return ResponseBuilder::generateError(500, server, req);
     }
 
-    size_t headerPos = *headerEndOpt;
+    size_t      headerPos     = *headerEndOpt;
     std::string headerSection = initialData.substr(0, headerPos);
-    auto [code, contentType] = parseHeaders(headerSection);
+    auto [code, contentType]  = parseHeaders(headerSection);
 
     std::streamsize headerEnd = static_cast<std::streamsize>(headerPos + delimLen);
     std::streamsize bodySize  = totalSize - headerEnd;
@@ -330,7 +331,8 @@ void errorOnCgi(CgiProcess& cgi) {
     kill(cgi.pid, SIGKILL);
     if (waitpid(cgi.pid, nullptr, 0) == -1) {
         Logger::logFrom(LogLevel::ERROR, "CGI",
-                        "waitpid failed after killing CGI process: " + std::string(strerror(errno)));
+                        "waitpid failed after killing CGI process: " +
+                            std::string(strerror(errno)));
     }
     unlinkWithErrorLog(cgi.input_path, "input temp file");
     unlinkWithErrorLog(cgi.output_path, "output temp file");

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/05 14:16:58 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 14:50:27 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -97,6 +97,12 @@ std::vector<char*> toCharPtrArray(const std::vector<std::string>& vs) {
 } // namespace
 
 namespace CGI {
+
+static void unlinkWithErrorLog(const std::string& path, const std::string& context) {
+    if (!path.empty() && unlink(path.c_str()) != 0) {
+        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete " + context + ": " + path);
+    }
+}
 
 bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& server,
                     const Location& loc, const std::vector<pollfd>& poll_fds) {
@@ -256,7 +262,7 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
     std::streamsize headerEnd = static_cast<std::streamsize>(pos + delimLen);
     std::streamsize bodySize  = totalSize - headerEnd;
     in.close();
-	req.printRequest();
+    req.printRequest();
     HttpResponse resp = ResponseBuilder::generateSuccessFile(code, cgi.output_path, contentType,
                                                              req, bodySize, headerEnd);
     resp.setCgiTempFile(cgi.output_path);
@@ -264,16 +270,12 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
 }
 
 void errorOnCgi(CgiProcess& cgi) {
-    Logger::logFrom(LogLevel::kDEBUG, "CGI",
+    Logger::logFrom(LogLevel::ERROR, "CGI",
                     "Killing CGI process with PID: " + std::to_string(cgi.pid));
     kill(cgi.pid, SIGKILL);
     waitpid(cgi.pid, nullptr, 0);
-    if (!cgi.input_path.empty() && unlink(cgi.input_path.c_str()) != 0) {
-		Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete input temp file: " + cgi.input_path);
-	}
-	if (!cgi.output_path.empty() && unlink(cgi.output_path.c_str()) != 0) {
-		Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete output temp file: " + cgi.output_path);
-	}
+    unlinkWithErrorLog(cgi.input_path, "input temp file");
+    unlinkWithErrorLog(cgi.output_path, "output temp file");
 
     cgi.pid           = -1;
     cgi.start_time    = 0;
@@ -283,9 +285,7 @@ void errorOnCgi(CgiProcess& cgi) {
 }
 
 void cleanupCgi(CgiProcess& cgi) {
-    if (!cgi.input_path.empty() && unlink(cgi.input_path.c_str()) != 0) {
-        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete input temp file: " + cgi.input_path);
-    }
+    unlinkWithErrorLog(cgi.input_path, "input temp file");
     cgi.pid           = -1;
     cgi.start_time    = 0;
     cgi.last_activity = 0;

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/06 12:55:57 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:07:40 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -328,7 +328,10 @@ void errorOnCgi(CgiProcess& cgi) {
     Logger::logFrom(LogLevel::ERROR, "CGI",
                     "Killing CGI process with PID: " + std::to_string(cgi.pid));
     kill(cgi.pid, SIGKILL);
-    waitpid(cgi.pid, nullptr, 0);
+    if (waitpid(cgi.pid, nullptr, 0) == -1) {
+        Logger::logFrom(LogLevel::ERROR, "CGI",
+                        "waitpid failed after killing CGI process: " + std::string(strerror(errno)));
+    }
     unlinkWithErrorLog(cgi.input_path, "input temp file");
     unlinkWithErrorLog(cgi.output_path, "output temp file");
 

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/06 12:26:29 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 12:46:48 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -256,7 +256,7 @@ void unlinkWithErrorLog(const std::string& path, const std::string& context) {
 
 bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& server,
                     const Location& loc, const std::vector<pollfd>& poll_fds, int& errorCode) {
-    cgi.last_activity = time(NULL);
+    cgi.last_activity = getCurrentTime();
     cgi.script_path   = std::filesystem::absolute(loc.resolveAbsolutePath(req.getPath()));
     if (!validateCgiScript(cgi.script_path, errorCode)) {
         return false;
@@ -267,7 +267,7 @@ bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& serve
         errorCode = 500;
         return false;
     }
-    cgi.last_activity = time(NULL);
+    cgi.last_activity = getCurrentTime();
 
     pid_t pid = fork();
     if (pid < 0) {
@@ -284,14 +284,14 @@ bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& serve
     close(output_fd);
 
     cgi.pid           = pid;
-    cgi.start_time    = time(NULL);
-    cgi.last_activity = time(NULL);
+    cgi.start_time    = getCurrentTime();
+    cgi.last_activity = getCurrentTime();
     return true;
 }
 
 HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpRequest& req) {
 
-    cgi.last_activity = time(NULL);
+    cgi.last_activity = getCurrentTime();
     std::ifstream in(cgi.output_path, std::ios::binary);
     if (!in.is_open()) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to open CGI output file");

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/05 15:15:56 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 12:26:29 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -94,70 +94,99 @@ std::vector<char*> toCharPtrArray(const std::vector<std::string>& vs) {
     return out;
 }
 
-} // namespace
-
-namespace CGI {
-
-void unlinkWithErrorLog(const std::string& path, const std::string& context) {
-    if (!path.empty() && unlink(path.c_str()) != 0) {
-        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete " + context + ": " + path);
-    }
+std::pair<std::string, std::streamsize> readInitialOutput(std::ifstream& file, size_t maxBytes) {
+    std::vector<char> buffer(maxBytes);
+    file.read(buffer.data(), maxBytes);
+    std::streamsize bytesRead = file.gcount();
+    return { std::string(buffer.data(), bytesRead), bytesRead };
 }
 
-bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& server,
-                    const Location& loc, const std::vector<pollfd>& poll_fds, int& errorCode) {
-    cgi.last_activity = time(NULL);
-    cgi.script_path   = std::filesystem::absolute(loc.resolveAbsolutePath(req.getPath()));
-    if (!isFile(cgi.script_path)) {
+std::optional<size_t> findHeaderDelimiter(const std::string& data, size_t& delimiterLength) {
+    size_t pos = data.find("\r\n\r\n");
+    delimiterLength = 4;
+    if (pos == std::string::npos) {
+        pos = data.find("\n\n");
+        delimiterLength = 2;
+    }
+    if (pos != std::string::npos) {
+        return std::optional<size_t>(pos);
+    }
+    return std::nullopt;
+}
+
+std::pair<int, std::string> parseHeaders(const std::string& header) {
+    std::istringstream stream(header);
+    std::string line, contentType = "";
+    int statusCode = 200;
+
+    while (std::getline(stream, line)) {
+        if (line.find("Content-Type:") == 0)
+            contentType = trim(line.substr(13));
+        else if (line.find("Status:") == 0) {
+            try {
+                statusCode = std::stoi(trim(line.substr(7)));
+            } catch (...) {
+                Logger::logFrom(LogLevel::WARN, "CGI", "Invalid status code in CGI response");
+                statusCode = 500;
+            }
+        }
+    }
+    return { statusCode, contentType };
+}
+
+bool validateCgiScript(const std::filesystem::path& path, int& errorCode) {
+    if (!isFile(path)) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "File is invalid");
         errorCode = 404;
         return false;
     }
-    if (access(cgi.script_path.c_str(), X_OK) != 0) {
+    if (access(path.c_str(), X_OK) != 0) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "File is not executable");
         errorCode = 403;
         return false;
     }
+    return true;
+}
 
-    // === Generate a unique temporary file path ===
-    static unsigned counter  = 0;
-    std::string     temp_in  = make_temp_name("webserv_in", counter);
-    std::string     temp_out = make_temp_name("webserv_out", counter);
-    cgi.input_path           = temp_in;
-    cgi.output_path          = temp_out;
+bool prepareCgiTempFiles(CgiProcess& cgi, const HttpRequest& req, int& bodyFd, int& outputFd) {
+    static unsigned counter = 0;
+    cgi.input_path  = make_temp_name("webserv_in", counter);
+    cgi.output_path = make_temp_name("webserv_out", counter);
 
-    // === Write request body to temp file ===
-    std::ofstream out(temp_in, std::ios::binary);
+    std::ofstream out(cgi.input_path, std::ios::binary);
     if (!out.is_open()) {
-        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to create temp file");
+        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to create temp input file");
         return false;
     }
     out.write(req.getBody().data(), req.getBody().size());
     out.close();
 
-    // === Open the temp file for reading ===
-    int body_fd = open(temp_in.c_str(), O_RDONLY);
-    if (body_fd < 0) {
+    bodyFd = open(cgi.input_path.c_str(), O_RDONLY);
+    if (bodyFd < 0) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to reopen temp_in file for CGI input");
         return false;
     }
-    cgi.last_activity = time(NULL);
-    int output_fd     = open(temp_out.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
-    if (output_fd < 0) {
+
+    outputFd = open(cgi.output_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, 0600);
+    if (outputFd < 0) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to create CGI output file");
-        close(body_fd);
+        close(bodyFd);
         return false;
     }
 
-    pid_t pid = fork();
-    if (pid < 0) {
-        close(body_fd);
-        close(output_fd);
-        return false;
-    }
+    return true;
+}
 
-    if (pid == 0) {
-        if (dup2(body_fd, STDIN_FILENO) == -1) {
+void setupAndRunCgiChild(
+    const CgiProcess& cgi,
+    int body_fd,
+    int output_fd,
+    const HttpRequest& req,
+    const Server& server,
+    const Location& loc,
+    const std::vector<pollfd>& poll_fds)
+{
+    if (dup2(body_fd, STDIN_FILENO) == -1) {
             Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
                             "dup2 stdin failed: " + std::string(strerror(errno)));
             exit(1);
@@ -212,6 +241,43 @@ bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& serve
         Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
                         "execve failed: " + std::string(strerror(errno)));
         exit(1);
+}
+
+
+} // namespace
+
+namespace CGI {
+
+void unlinkWithErrorLog(const std::string& path, const std::string& context) {
+    if (!path.empty() && unlink(path.c_str()) != 0) {
+        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete " + context + ": " + path);
+    }
+}
+
+bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& server,
+                    const Location& loc, const std::vector<pollfd>& poll_fds, int& errorCode) {
+    cgi.last_activity = time(NULL);
+    cgi.script_path   = std::filesystem::absolute(loc.resolveAbsolutePath(req.getPath()));
+    if (!validateCgiScript(cgi.script_path, errorCode)) {
+        return false;
+    }
+
+    int body_fd = -1, output_fd = -1;
+    if (!prepareCgiTempFiles(cgi, req, body_fd, output_fd)) {
+        errorCode = 500;
+        return false;
+    }
+    cgi.last_activity = time(NULL);
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(body_fd);
+        close(output_fd);
+        return false;
+    }
+
+    if (pid == 0) {
+        setupAndRunCgiChild(cgi, body_fd, output_fd, req, server, loc, poll_fds);
     }
 
     close(body_fd);
@@ -237,39 +303,20 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
     in.seekg(0, std::ios::beg);
 
     // Read the first 9KB only to find headers
-    const size_t      MAX_HEADER_SCAN = 9 * 1024;
-    std::vector<char> buffer(MAX_HEADER_SCAN);
-    in.read(buffer.data(), MAX_HEADER_SCAN);
-    std::streamsize bytesRead = in.gcount();
-    std::string     partialOutput(buffer.data(), bytesRead);
-
-    // Look for header delimiter
-    size_t pos      = partialOutput.find("\r\n\r\n");
-    size_t delimLen = 4;
-    if (pos == std::string::npos) {
-        pos      = partialOutput.find("\n\n");
-        delimLen = 2;
-    }
-    if (pos == std::string::npos) {
-        Logger::logFrom(LogLevel::ERROR, "CGI",
-                        "finalizeCgi(): Header delimiter not found in first 9KB");
+    constexpr size_t MAX_HEADER_SCAN = 9 * 1024;
+    auto [initialData, bytesRead] = readInitialOutput(in, MAX_HEADER_SCAN);
+    size_t delimLen = 0;
+    auto headerEndOpt = findHeaderDelimiter(initialData, delimLen);
+    if (!headerEndOpt) {
+        Logger::logFrom(LogLevel::ERROR, "CGI", "Header delimiter not found in first 9KB");
         return ResponseBuilder::generateError(500, server, req);
     }
 
-    std::string header      = partialOutput.substr(0, pos);
-    std::string contentType = "text/plain";
-    int         code        = 200;
+    size_t headerPos = *headerEndOpt;
+    std::string headerSection = initialData.substr(0, headerPos);
+    auto [code, contentType] = parseHeaders(headerSection);
 
-    std::istringstream headerStream(header);
-    std::string        line;
-    while (std::getline(headerStream, line)) {
-        if (line.find("Content-Type:") == 0)
-            contentType = trim(line.substr(13));
-        else if (line.find("Status:") == 0)
-            code = std::stoi(trim(line.substr(7)));
-    }
-
-    std::streamsize headerEnd = static_cast<std::streamsize>(pos + delimLen);
+    std::streamsize headerEnd = static_cast<std::streamsize>(headerPos + delimLen);
     std::streamsize bodySize  = totalSize - headerEnd;
     in.close();
     req.printRequest();

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,17 +6,15 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/06 12:46:48 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 12:55:57 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "http/handleCgi.hpp"
 #include "http/HttpResponseBuilder.hpp"
-#include "network/SocketManager.hpp"
 #include "utils/Logger.hpp"
 #include "utils/filesystemUtils.hpp"
 #include "utils/stringUtils.hpp"
-#include <cstdio>
 #include <fcntl.h>
 #include <filesystem>
 #include <fstream>

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/04 15:07:40 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 12:26:34 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -220,8 +220,8 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
     std::streamsize totalSize = in.tellg();
     in.seekg(0, std::ios::beg);
 
-    // Read the first 16KB only to find headers
-    const size_t      MAX_HEADER_SCAN = 16 * 1024;
+    // Read the first 9KB only to find headers
+    const size_t      MAX_HEADER_SCAN = 9 * 1024;
     std::vector<char> buffer(MAX_HEADER_SCAN);
     in.read(buffer.data(), MAX_HEADER_SCAN);
     std::streamsize bytesRead = in.gcount();
@@ -236,7 +236,7 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
     }
     if (pos == std::string::npos) {
         Logger::logFrom(LogLevel::ERROR, "CGI",
-                        "finalizeCgi(): Header delimiter not found in first 16KB");
+                        "finalizeCgi(): Header delimiter not found in first 9KB");
         return ResponseBuilder::generateError(500, server, req);
     }
 

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/05 14:50:27 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 15:15:56 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -98,22 +98,24 @@ std::vector<char*> toCharPtrArray(const std::vector<std::string>& vs) {
 
 namespace CGI {
 
-static void unlinkWithErrorLog(const std::string& path, const std::string& context) {
+void unlinkWithErrorLog(const std::string& path, const std::string& context) {
     if (!path.empty() && unlink(path.c_str()) != 0) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete " + context + ": " + path);
     }
 }
 
 bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& server,
-                    const Location& loc, const std::vector<pollfd>& poll_fds) {
+                    const Location& loc, const std::vector<pollfd>& poll_fds, int& errorCode) {
     cgi.last_activity = time(NULL);
     cgi.script_path   = std::filesystem::absolute(loc.resolveAbsolutePath(req.getPath()));
     if (!isFile(cgi.script_path)) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "File is invalid");
+        errorCode = 404;
         return false;
     }
     if (access(cgi.script_path.c_str(), X_OK) != 0) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "File is not executable");
+        errorCode = 403;
         return false;
     }
 
@@ -155,9 +157,17 @@ bool initCgiProcess(CgiProcess& cgi, const HttpRequest& req, const Server& serve
     }
 
     if (pid == 0) {
-        dup2(body_fd, STDIN_FILENO);
+        if (dup2(body_fd, STDIN_FILENO) == -1) {
+            Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
+                            "dup2 stdin failed: " + std::string(strerror(errno)));
+            exit(1);
+        }
         close(body_fd);
-        dup2(output_fd, STDOUT_FILENO);
+        if (dup2(output_fd, STDOUT_FILENO) == -1) {
+            Logger::logFrom(LogLevel::ERROR, "CGI CHILD",
+                            "dup2 stdout failed: " + std::string(strerror(errno)));
+            exit(1);
+        }
         close(output_fd);
         for (std::vector<pollfd>::const_iterator it = poll_fds.begin(); it != poll_fds.end();
              ++it) {

--- a/src/http/handleCgi.cpp
+++ b/src/http/handleCgi.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/24 12:23:37 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/05 12:26:34 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 14:16:58 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -260,11 +260,6 @@ HttpResponse finalizeCgi(CgiProcess& cgi, const Server& server, const HttpReques
     HttpResponse resp = ResponseBuilder::generateSuccessFile(code, cgi.output_path, contentType,
                                                              req, bodySize, headerEnd);
     resp.setCgiTempFile(cgi.output_path);
-    Logger::logFrom(LogLevel::kDEBUG, "CGI",
-                    "CGI process completed with PID: " + std::to_string(cgi.pid) +
-                        ", output file: " + cgi.output_path +
-                        ", status code: " + std::to_string(code));
-
     return resp;
 }
 
@@ -273,23 +268,12 @@ void errorOnCgi(CgiProcess& cgi) {
                     "Killing CGI process with PID: " + std::to_string(cgi.pid));
     kill(cgi.pid, SIGKILL);
     waitpid(cgi.pid, nullptr, 0);
-    if (!cgi.input_path.empty()) {
-        if (unlink(cgi.input_path.c_str()) == 0) {
-            Logger::logFrom(LogLevel::kDEBUG, "CGI", "Deleted input temp file: " + cgi.input_path);
-        } else {
-            Logger::logFrom(LogLevel::ERROR, "CGI",
-                            "Failed to delete input temp file: " + cgi.input_path);
-        }
-    }
-    if (!cgi.output_path.empty()) {
-        if (unlink(cgi.output_path.c_str()) == 0) {
-            Logger::logFrom(LogLevel::kDEBUG, "CGI",
-                            "Deleted output temp file: " + cgi.output_path);
-        } else {
-            Logger::logFrom(LogLevel::ERROR, "CGI",
-                            "Failed to delete output temp file: " + cgi.output_path);
-        }
-    }
+    if (!cgi.input_path.empty() && unlink(cgi.input_path.c_str()) != 0) {
+		Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete input temp file: " + cgi.input_path);
+	}
+	if (!cgi.output_path.empty() && unlink(cgi.output_path.c_str()) != 0) {
+		Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete output temp file: " + cgi.output_path);
+	}
 
     cgi.pid           = -1;
     cgi.start_time    = 0;
@@ -299,14 +283,8 @@ void errorOnCgi(CgiProcess& cgi) {
 }
 
 void cleanupCgi(CgiProcess& cgi) {
-    // Only delete input file (output file is managed by HttpResponse)
-    if (!cgi.input_path.empty()) {
-        if (unlink(cgi.input_path.c_str()) == 0) {
-            Logger::logFrom(LogLevel::kDEBUG, "CGI", "Deleted input temp file: " + cgi.input_path);
-        } else {
-            Logger::logFrom(LogLevel::ERROR, "CGI",
-                            "Failed to delete input temp file: " + cgi.input_path);
-        }
+    if (!cgi.input_path.empty() && unlink(cgi.input_path.c_str()) != 0) {
+        Logger::logFrom(LogLevel::ERROR, "CGI", "Failed to delete input temp file: " + cgi.input_path);
     }
     cgi.pid           = -1;
     cgi.start_time    = 0;
@@ -326,8 +304,6 @@ bool tryTerminateCgi(CgiProcess& cgi) {
         Logger::logFrom(LogLevel::ERROR, "CGI", "waitpid failed: " + std::string(strerror(errno)));
         return true;
     }
-    Logger::logFrom(LogLevel::kDEBUG, "CGI",
-                    "CGI process terminated with PID: " + std::to_string(cgi.pid));
     return true;
 }
 

--- a/src/http/handle_get.cpp
+++ b/src/http/handle_get.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   handle_get.cpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nlouis <nlouis@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 12:39:41 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/04 22:37:35 by nlouis           ###   ########.fr       */
+/*   Updated: 2025/06/06 13:40:46 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,6 +15,7 @@
 #include <ctime>
 #include <dirent.h>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <sys/stat.h>
 #include <vector>

--- a/src/network/SocketManager.cpp
+++ b/src/network/SocketManager.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:20 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/05 16:17:31 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 12:47:03 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -173,7 +173,7 @@ bool SocketManager::checkClientTimeouts(int client_fd, size_t index) {
     if (!_client_info.count(client_fd))
         return false;
 
-    time_t now = time(NULL);
+    time_t now = getCurrentTime();
     if (isIdleTimeout(client_fd, now) || isSendTimeout(client_fd, now)) {
         cleanupClientConnectionClose(client_fd, index);
         return false;
@@ -201,7 +201,7 @@ void SocketManager::handlePollError(int fd, size_t index, short revents) {
 
 bool SocketManager::receiveFromClient(int client_fd, size_t index) {
     char buffer[RECV_BUFFER];
-    _client_info[client_fd].lastRequestTime = time(NULL);
+    _client_info[client_fd].lastRequestTime = getCurrentTime();
     int bytes = recv(client_fd, buffer, sizeof(buffer) - 1, 0); // MacOS only
     // int bytes = recv(client_fd, buffer, sizeof(buffer) - 1, MSG_DONTWAIT);
     if (bytes == 0) {
@@ -224,7 +224,7 @@ bool SocketManager::receiveFromClient(int client_fd, size_t index) {
 
     if (headerEndPos == std::string::npos) {
         if (_client_info[client_fd].headerBytesReceived == 0) {
-            _client_info[client_fd].connectionStartTime = time(NULL);
+            _client_info[client_fd].connectionStartTime = getCurrentTime();
         }
         _client_info[client_fd].headerBytesReceived += bytes;
     } else {
@@ -347,7 +347,7 @@ void SocketManager::run() {
             CgiProcess& cgi = *client.cgiProcess;
 
             // timeout check
-            if (time(NULL) - cgi.last_activity > CGI_TIMEOUT_SECONDS) {
+            if (getCurrentTime() - cgi.last_activity > CGI_TIMEOUT_SECONDS) {
                 Logger::logFrom(LogLevel::WARN, "CGI",
                                 "Timeout. Killing CGI process for fd: " +
                                     std::to_string(client_fd));
@@ -464,8 +464,8 @@ void SocketManager::handleNewConnection(int listen_fd) {
 
     auto& info               = _client_info[client_fd];
     info.client_fd           = client_fd;
-    info.lastRequestTime     = time(NULL);
-    info.connectionStartTime = time(NULL);
+    info.lastRequestTime     = getCurrentTime();
+    info.connectionStartTime = getCurrentTime();
     info.headerBytesReceived = 0;
     info.bodyBytesReceived   = 0;
     info.headerComplete      = false;
@@ -707,7 +707,7 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
                 return;
             }
             offset += sent;
-            _client_info[client_fd].lastSendAttemptTime = time(NULL);
+            _client_info[client_fd].lastSendAttemptTime = getCurrentTime();
             if (offset < raw.size()) {
                 // Not done sending headers yet; wait for next POLLOUT
                 return;
@@ -727,7 +727,7 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
                 cleanupClientConnectionClose(client_fd, index);
                 return;
             }
-            _client_info[client_fd].lastSendAttemptTime = time(NULL);
+            _client_info[client_fd].lastSendAttemptTime = getCurrentTime();
             // ─────────────────────────────────────────────────────────────────
             // IMPORTANT: Do NOT modify `offset` here. It tracks only how many
             // bytes of `current_raw_response` have been sent.
@@ -782,7 +782,7 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
                 return;
             }
             offset += bytes_sent;
-            _client_info[client_fd].lastSendAttemptTime = time(NULL);
+            _client_info[client_fd].lastSendAttemptTime = getCurrentTime();
         }
 
         if (offset >= raw.size()) {

--- a/src/network/SocketManager.cpp
+++ b/src/network/SocketManager.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:20 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/05 12:17:09 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 14:33:12 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,8 +56,6 @@ void SocketManager::cleanupCgiForClient(int client_fd) {
 }
 
 void SocketManager::cleanupClientConnectionClose(int client_fd, size_t index) {
-    Logger::logFrom(LogLevel::kDEBUG, "SocketManager cleanupClientConnectionClose",
-                    "Called cleanup for fd: " + std::to_string(client_fd));
     // 1. Defensive: bounds check for poll index
     if (index < _poll_fds.size()) {
         _poll_fds.erase(_poll_fds.begin() + index);
@@ -75,14 +73,9 @@ void SocketManager::cleanupClientConnectionClose(int client_fd, size_t index) {
             // Delete temporary files from CGI responses
             if (resp.isCgiTempFile()) {
                 const std::string& path = resp.getCgiTempFile();
-                if (!path.empty()) {
-                    if (unlink(path.c_str()) == 0) {
-                        Logger::logFrom(LogLevel::kDEBUG, "SocketManager",
-                                        "Deleted temp file: " + path);
-                    } else {
-                        Logger::logFrom(LogLevel::ERROR, "SocketManager",
-                                        "Failed to delete temp file: " + path);
-                    }
+                if (!path.empty() && unlink(path.c_str()) != 0) {
+                    Logger::logFrom(LogLevel::ERROR, "SocketManager",
+                                    "Failed to delete temp file: " + path);
                 }
             }
             client.responses.pop();
@@ -236,14 +229,12 @@ bool SocketManager::receiveFromClient(int client_fd, size_t index) {
     size_t headerEndPos = _client_info[client_fd].requestBuffer.find("\r\n\r\n");
 
     if (headerEndPos == std::string::npos) {
-        Logger::logFrom(LogLevel::kDEBUG, "SocketManager", "Did not find end of header");
         if (_client_info[client_fd].headerBytesReceived == 0) {
             _client_info[client_fd].connectionStartTime = time(NULL);
         }
         _client_info[client_fd].headerBytesReceived += bytes;
     } else {
         if (!_client_info[client_fd].headerComplete) {
-            Logger::logFrom(LogLevel::kDEBUG, "SocketManager", "Found end of header");
             size_t fullHeaderSize = headerEndPos + 4;
             size_t oldBufferSize  = _client_info[client_fd].requestBuffer.size() - bytes;
             size_t headerBytesThisTime =
@@ -254,8 +245,6 @@ bool SocketManager::receiveFromClient(int client_fd, size_t index) {
         } else {
             // Header already counted, this must be body
             _client_info[client_fd].bodyBytesReceived += bytes;
-            // Logger::logFrom(LogLevel::kDEBUG, "SocketManager", "Received body data, total body
-            // bytes: " + std::to_string(_client_info[client_fd].bodyBytesReceived));
         }
     }
 
@@ -635,11 +624,6 @@ bool SocketManager::handleClientData(int client_fd, size_t index) {
             } else {
                 request.setParseErrorCode(errorCode);
                 request.printRequest();
-                Logger::logFrom(LogLevel::kDEBUG, "SocketManager",
-                    "[2]requestBuffer size is {" + std::to_string(client.requestBuffer.size()) +
-                        "}, [2]consumedBytes size is {" + std::to_string(consumedBytes) +
-                        "}, [2]requestBuffer size after erase is {" +
-                        std::to_string(client.requestBuffer.size() - consumedBytes) + "}");
                 if (errorCode == 415 || errorCode == 411 || errorCode == 400 || errorCode == 413) {
                     client.requestBuffer.clear();
                 } else {
@@ -655,13 +639,6 @@ bool SocketManager::handleClientData(int client_fd, size_t index) {
                           // pipeline
             }
         }
-        Logger::logFrom(
-            LogLevel::kDEBUG, "SocketManager",
-            "[3]requestBuffer size is {" +
-                std::to_string(client.requestBuffer.size()) +
-                "}, [3]consumedBytes size is {" + std::to_string(consumedBytes) +
-                "}, [3]requestBuffer size after erase is {" +
-                std::to_string(client.requestBuffer.size() - consumedBytes) + "}");
         client.requestBuffer.erase(0, consumedBytes);
         resetRequestState(client_fd);
         client.pendingRequests.push(request);
@@ -677,9 +654,27 @@ bool SocketManager::handleClientData(int client_fd, size_t index) {
 
 void SocketManager::sendResponse(int client_fd, size_t index) {
     HttpResponse& response = _client_info[client_fd].responses.front();
-    Logger::logFrom(LogLevel::INFO, "SocketManager sendResponse",
-                    "Sending HTTP " + std::to_string(response.getStatusCode()) + " → fd " +
-                        std::to_string(client_fd));
+
+    // Log at appropriate level based on status code
+    int status = response.getStatusCode();
+    if (status >= 200 && status < 400) {
+        Logger::logFrom(LogLevel::INFO, "SocketManager sendResponse",
+                        "Sending HTTP " + std::to_string(status) + " → fd " +
+                            std::to_string(client_fd));
+    } else if (status >= 400 && status < 500) {
+        Logger::logFrom(LogLevel::WARN, "SocketManager sendResponse",
+                        "Sending HTTP " + std::to_string(status) + " → fd " +
+                            std::to_string(client_fd));
+    } else if (status >= 500) {
+        Logger::logFrom(LogLevel::ERROR, "SocketManager sendResponse",
+                        "Sending HTTP " + std::to_string(status) + " → fd " +
+                            std::to_string(client_fd));
+    } else {
+        Logger::logFrom(LogLevel::kDEBUG, "SocketManager sendResponse",
+                        "Sending HTTP " + std::to_string(status) + " → fd " +
+                            std::to_string(client_fd));
+    }
+
     size_t& offset = _client_info[client_fd].bytes_sent;
 
     if (response.isFileResponse()) {
@@ -718,9 +713,6 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
                 cleanupClientConnectionClose(client_fd, index);
                 return;
             }
-            Logger::logFrom(LogLevel::kDEBUG, "SocketManager sendResponse",
-                            "from raw headers, sent " + std::to_string(sent) +
-                                " bytes for fd: " + std::to_string(client_fd));
             offset += sent;
             _client_info[client_fd].lastSendAttemptTime = time(NULL);
             if (offset < raw.size()) {
@@ -733,10 +725,6 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
         char buffer[8192];
         _client_info[client_fd].file_stream.read(buffer, sizeof(buffer));
         std::streamsize bytes_read = _client_info[client_fd].file_stream.gcount();
-        Logger::logFrom(LogLevel::kDEBUG, "SocketManager sendResponse",
-                        "from file stream, read " + std::to_string(bytes_read) +
-                            " bytes for fd: " + std::to_string(client_fd));
-
         if (bytes_read > 0) {
             ssize_t sent = send(client_fd, buffer, bytes_read, MSG_DONTWAIT);
             if (sent < 0) {
@@ -746,9 +734,6 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
                 cleanupClientConnectionClose(client_fd, index);
                 return;
             }
-            Logger::logFrom(LogLevel::kDEBUG, "SocketManager sendResponse",
-                            "from file stream, sent " + std::to_string(sent) +
-                                " bytes for fd: " + std::to_string(client_fd));
             _client_info[client_fd].lastSendAttemptTime = time(NULL);
             // ─────────────────────────────────────────────────────────────────
             // IMPORTANT: Do NOT modify `offset` here. It tracks only how many
@@ -758,8 +743,8 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
 
         // If EOF reached or zero bytes were read, finish up and clean state
         if (_client_info[client_fd].file_stream.eof() || bytes_read == 0) {
-            Logger::logFrom(LogLevel::kDEBUG, "SocketManager eof()",
-                            "[✅DONE] We sent FILE RESPONSE to fd:" + std::to_string(client_fd));
+            Logger::logFrom(LogLevel::INFO, "SocketManager sendResponse",
+                            "[DONE] We sent full FILE RESPONSE to fd:" + std::to_string(client_fd));
             _client_info[client_fd].file_stream.close();
             _client_info[client_fd].current_raw_response.clear();
             offset = 0;
@@ -767,18 +752,18 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
             // If this was a temporary CGI file, delete it now
             if (response.isCgiTempFile()) {
                 const std::string& path = response.getCgiTempFile();
-                if (!path.empty() && unlink(path.c_str()) == 0) {
-                    Logger::logFrom(LogLevel::kDEBUG, "SocketManager",
-                                    "Deleted temp file: " + path);
-                    response.setCgiTempFile("");
+                if (!path.empty() && unlink(path.c_str()) != 0) {
+                    Logger::logFrom(LogLevel::ERROR, "SocketManager",
+                                    "Failed to delete temp file: " + path);
                 }
+                response.setCgiTempFile("");
             }
 
             _client_info[client_fd].responses.pop();
 
             if (!response.isConnectionClose()) {
                 if (_client_info[client_fd].responses.empty()) {
-                    Logger::logFrom(LogLevel::kDEBUG, "SocketManager",
+                    Logger::logFrom(LogLevel::INFO, "SocketManager",
                                     "Connection: keep-alive - keeping the connection open");
                     _poll_fds[index].events &= ~POLLOUT;
                 }
@@ -814,12 +799,12 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
         if (offset >= raw.size()) {
             _client_info[client_fd].responses.pop();
             offset = 0;
-            Logger::logFrom(LogLevel::kDEBUG, "SocketManager sendResponse",
-                            "[✅DONE] We sent RESPONSE to fd:" + std::to_string(client_fd));
+            Logger::logFrom(LogLevel::INFO, "SocketManager sendResponse",
+                            "[DONE] We sent full RESPONSE to fd:" + std::to_string(client_fd));
             _client_info[client_fd].current_raw_response.clear();
             if (!response.isConnectionClose()) {
                 if (_client_info[client_fd].responses.empty()) {
-                    Logger::logFrom(LogLevel::kDEBUG, "SocketManager",
+                    Logger::logFrom(LogLevel::INFO, "SocketManager",
                                     "Connection: keep-alive - keeping the connection open");
                     _poll_fds[index].events &= ~POLLOUT;
                 }

--- a/src/network/SocketManager.cpp
+++ b/src/network/SocketManager.cpp
@@ -6,19 +6,30 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:20 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/06 12:47:03 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:26:16 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "network/SocketManager.hpp"
-#include "http/HttpRequest.hpp"
-#include "http/HttpRequestHandler.hpp"
-#include "http/HttpRequestParser.hpp"
-#include "http/HttpResponse.hpp"
-#include "http/HttpResponseBuilder.hpp"
-#include "utils/Logger.hpp"
-#include "utils/filesystemUtils.hpp"
-#include <sstream> // For stringstream, we will remove it later
+#include "core/Location.hpp"            // for Location
+#include "http/HttpRequest.hpp"         // for HttpRequest
+#include "http/HttpRequestHandler.hpp"  // for handleRequest
+#include "http/HttpRequestParser.hpp"   // for HttpRequestParser
+#include "http/HttpResponse.hpp"        // for HttpResponse
+#include "http/HttpResponseBuilder.hpp" // for generateError
+#include "utils/Logger.hpp"             // for LogLevel, Logger
+#include "utils/filesystemUtils.hpp"    // for getCurrentTime, normalizePath
+#include <algorithm>                    // for copy, max
+#include <arpa/inet.h>                  // for inet_addr, htons
+#include <bits/types/sig_atomic_t.h>    // for sig_atomic_t
+#include <cstring>                      // for strerror, NULL, size_t
+#include <errno.h>                      // for errno, EINTR, EMFILE, ENFILE
+#include <fcntl.h>                      // for fcntl, F_SETFL, O_NONBLOCK
+#include <netinet/in.h>                 // for sockaddr_in, in_addr
+#include <sstream>                      // for basic_ostringstream
+#include <sys/socket.h>                 // for send, MSG_DONTWAIT, AF_INET
+#include <unistd.h>                     // for close, ssize_t
+#include <utility>                      // for pair
 
 // Signal handler for exiting the server
 static volatile sig_atomic_t running = 1;

--- a/src/network/SocketManager.cpp
+++ b/src/network/SocketManager.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:20 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/05 14:55:45 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 16:17:31 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -489,15 +489,17 @@ bool SocketManager::handleCgiRequest(int client_fd, const HttpRequest& request,
     ClientInfo& client = _client_info[client_fd];
     client.cgiProcess.emplace();
 
-    if (!CGI::initCgiProcess(*client.cgiProcess, request, server, location, _poll_fds)) {
+    int errorCode = 500;
+    if (!CGI::initCgiProcess(*client.cgiProcess, request, server, location, _poll_fds, errorCode)) {
         Logger::logFrom(LogLevel::ERROR, "SocketManager",
                         "[CGI] Failed to initialize CGI process for client_fd " +
                             std::to_string(client_fd) + " with script: " + location.getPath());
-        respondError(client_fd, 500);
+        HttpResponse err = ResponseBuilder::generateError(errorCode, server, request);
+        _client_info[client_fd].responses.push(err);
         client.cgiProcess.reset();
         client.isCgiProcessRunning = false;
         client.currentCgiRequest   = HttpRequest(); // clears request
-        return true;                                // error response queued
+        return false;                               // error response queued
     }
 
     return true; // handled as CGI
@@ -563,11 +565,14 @@ void SocketManager::processPendingRequests(int client_fd) {
             client.currentCgiRequest   = nextReq;
             client.isCgiProcessRunning = true;
 
-            /* bool ok =  */ (void) handleCgiRequest(client_fd, nextReq, server, *location);
+            bool ok = handleCgiRequest(client_fd, nextReq, server, *location);
             // handleCgiRequest(…) should already enqueue an error-response
             // if it fails to fork/exec. In that case, we want to remove this request
             // from pendingRequests anyway, so that we don’t loop infinitely:
             client.pendingRequests.pop();
+            if (!ok) {
+                continue;
+            }
             return; // Stop here. Wait for CGI to finish before doing anything else.
         }
 

--- a/src/network/SocketManager.cpp
+++ b/src/network/SocketManager.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:20 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/05 14:33:12 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 14:55:45 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,7 +52,7 @@ void SocketManager::cleanupCgiForClient(int client_fd) {
     CGI::cleanupCgi(*client.cgiProcess);
     client.cgiProcess.reset();
     client.isCgiProcessRunning = false;
-    client.currentCgiRequest = HttpRequest();
+    client.currentCgiRequest   = HttpRequest();
 }
 
 void SocketManager::cleanupClientConnectionClose(int client_fd, size_t index) {
@@ -72,11 +72,7 @@ void SocketManager::cleanupClientConnectionClose(int client_fd, size_t index) {
 
             // Delete temporary files from CGI responses
             if (resp.isCgiTempFile()) {
-                const std::string& path = resp.getCgiTempFile();
-                if (!path.empty() && unlink(path.c_str()) != 0) {
-                    Logger::logFrom(LogLevel::ERROR, "SocketManager",
-                                    "Failed to delete temp file: " + path);
-                }
+                CGI::unlinkWithErrorLog(resp.getCgiTempFile(), "out temp file");
             }
             client.responses.pop();
         }
@@ -86,7 +82,7 @@ void SocketManager::cleanupClientConnectionClose(int client_fd, size_t index) {
             CGI::errorOnCgi(*client.cgiProcess);
             client.cgiProcess.reset();
             client.isCgiProcessRunning = false;
-            client.currentCgiRequest = HttpRequest();
+            client.currentCgiRequest   = HttpRequest();
         }
 
         // Close file stream
@@ -193,15 +189,13 @@ void SocketManager::handlePollError(int fd, size_t index, short revents) {
     if (revents & POLLNVAL) {
         Logger::logFrom(LogLevel::ERROR, "SocketManager",
                         "Invalid poll event on fd: " + std::to_string(fd));
-    }
-    else if (revents & POLLERR) {
+    } else if (revents & POLLERR) {
         Logger::logFrom(LogLevel::ERROR, "SocketManager",
                         "Socket error on fd: " + std::to_string(fd));
-    }
-    else if (revents & POLLHUP) {
+    } else if (revents & POLLHUP) {
         Logger::logFrom(LogLevel::INFO, "SocketManager",
                         "Client disconnected (POLLHUP) on fd: " + std::to_string(fd));
- }
+    }
     cleanupClientConnectionClose(fd, index);
 }
 
@@ -361,7 +355,7 @@ void SocketManager::run() {
                 CGI::errorOnCgi(cgi);
                 client.cgiProcess.reset();
                 client.isCgiProcessRunning = false;
-                client.currentCgiRequest = HttpRequest();  // clears request
+                client.currentCgiRequest   = HttpRequest(); // clears request
                 for (auto& pfd : _poll_fds) {
                     if (pfd.fd == client_fd) {
                         pfd.events |= POLLOUT;
@@ -380,8 +374,8 @@ void SocketManager::run() {
                 client.responses.push(resp);
                 CGI::cleanupCgi(cgi);
                 client.cgiProcess.reset();
-                client.isCgiProcessRunning = false;  // optional if used independently
-                client.currentCgiRequest = HttpRequest();  // clears request
+                client.isCgiProcessRunning = false;         // optional if used independently
+                client.currentCgiRequest   = HttpRequest(); // clears request
 
                 for (auto& pfd : _poll_fds) {
                     if (pfd.fd == client_fd) {
@@ -446,8 +440,9 @@ void SocketManager::handleNewConnection(int listen_fd) {
     if (client_fd < 0) {
         if (errno == EMFILE || errno == ENFILE) {
             // We’ve hit the per‐process or system FD limit.
-            Logger::logFrom(LogLevel::ERROR, "SocketManager",
-                            "Out of file descriptors (accept failed: " + std::string(strerror(errno)) + ")");
+            Logger::logFrom(
+                LogLevel::ERROR, "SocketManager",
+                "Out of file descriptors (accept failed: " + std::string(strerror(errno)) + ")");
             return;
         }
         Logger::logFrom(LogLevel::ERROR, "SocketManager",
@@ -501,8 +496,8 @@ bool SocketManager::handleCgiRequest(int client_fd, const HttpRequest& request,
         respondError(client_fd, 500);
         client.cgiProcess.reset();
         client.isCgiProcessRunning = false;
-        client.currentCgiRequest = HttpRequest(); // clears request
-        return true; // error response queued
+        client.currentCgiRequest   = HttpRequest(); // clears request
+        return true;                                // error response queued
     }
 
     return true; // handled as CGI
@@ -529,19 +524,18 @@ void SocketManager::processPendingRequests(int client_fd) {
         HttpRequest nextReq = client.pendingRequests.front();
 
         if (nextReq.getParseErrorCode() != 0) {
-            int code = nextReq.getParseErrorCode();
-            HttpResponse err =
-                ResponseBuilder::generateError(code, client.serverConfig, nextReq);
+            int          code = nextReq.getParseErrorCode();
+            HttpResponse err  = ResponseBuilder::generateError(code, client.serverConfig, nextReq);
             client.responses.push(err);
             client.pendingRequests.pop();
-            if (err.isConnectionClose()) return;
+            if (err.isConnectionClose())
+                return;
             continue;
         }
 
         // 1) Determine which Location matches
         const Server&   server   = client.serverConfig;
-        const Location* location =
-            findMatchingLocation(normalizePath(nextReq.getPath()), server);
+        const Location* location = findMatchingLocation(normalizePath(nextReq.getPath()), server);
 
         if (!location) {
             // No matching location → 404, enqueue it, then pop pendingRequests
@@ -560,17 +554,16 @@ void SocketManager::processPendingRequests(int client_fd) {
 
         // 2) Is it a CGI path?
         std::string resolved = location->resolveAbsolutePath(nextReq.getPath());
-        bool        wantCgi  =
-            !resolved.empty()
-            && (nextReq.getMethod() == "GET" || nextReq.getMethod() == "POST")
-            && location->isCgiRequest(normalizePath(nextReq.getPath()));
+        bool        wantCgi  = !resolved.empty() &&
+                       (nextReq.getMethod() == "GET" || nextReq.getMethod() == "POST") &&
+                       location->isCgiRequest(normalizePath(nextReq.getPath()));
 
         if (wantCgi) {
             // ── SPAWN A CGI ──
-            client.currentCgiRequest = nextReq;
+            client.currentCgiRequest   = nextReq;
             client.isCgiProcessRunning = true;
 
-            /* bool ok =  */(void)handleCgiRequest(client_fd, nextReq, server, *location);
+            /* bool ok =  */ (void) handleCgiRequest(client_fd, nextReq, server, *location);
             // handleCgiRequest(…) should already enqueue an error-response
             // if it fails to fork/exec. In that case, we want to remove this request
             // from pendingRequests anyway, so that we don’t loop infinitely:
@@ -596,7 +589,6 @@ void SocketManager::processPendingRequests(int client_fd) {
     // If we get here, either pendingRequests is empty, or there’s a CGI in flight.
 }
 
-
 bool SocketManager::handleClientData(int client_fd, size_t index) {
     if (!receiveFromClient(client_fd, index)) {
         return false;
@@ -611,13 +603,9 @@ bool SocketManager::handleClientData(int client_fd, size_t index) {
         HttpRequest request;
         int         errorCode     = 0;
         std::size_t consumedBytes = 0;
-        bool parseOK = HttpRequestParser::parse(
-            request,
-            client.requestBuffer,
-            client.serverConfig.getClientMaxBodySize(),
-            errorCode,
-            consumedBytes
-        );
+        bool        parseOK       = HttpRequestParser::parse(request, client.requestBuffer,
+                                                             client.serverConfig.getClientMaxBodySize(),
+                                                             errorCode, consumedBytes);
         if (!parseOK) {
             if (errorCode == 0) {
                 return false; // Incomplete data — wait for more
@@ -629,7 +617,7 @@ bool SocketManager::handleClientData(int client_fd, size_t index) {
                 } else {
                     client.requestBuffer.erase(0, consumedBytes);
                 }
-                resetRequestState(client_fd); //DO WE NEED IT?
+                resetRequestState(client_fd); // DO WE NEED IT?
                 client.pendingRequests.push(request);
                 // If no more complete request left, break
                 if (client.requestBuffer.find("\r\n\r\n") == std::string::npos) {
@@ -751,11 +739,7 @@ void SocketManager::sendResponse(int client_fd, size_t index) {
 
             // If this was a temporary CGI file, delete it now
             if (response.isCgiTempFile()) {
-                const std::string& path = response.getCgiTempFile();
-                if (!path.empty() && unlink(path.c_str()) != 0) {
-                    Logger::logFrom(LogLevel::ERROR, "SocketManager",
-                                    "Failed to delete temp file: " + path);
-                }
+                CGI::unlinkWithErrorLog(response.getCgiTempFile(), "out temp file");
                 response.setCgiTempFile("");
             }
 

--- a/src/network/SocketManager.cpp
+++ b/src/network/SocketManager.cpp
@@ -6,7 +6,7 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/03 13:51:20 by irychkov          #+#    #+#             */
-/*   Updated: 2025/06/05 10:57:29 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/05 12:17:09 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -197,12 +197,18 @@ bool SocketManager::checkClientTimeouts(int client_fd, size_t index) {
 }
 
 void SocketManager::handlePollError(int fd, size_t index, short revents) {
-    if (revents & POLLERR)
+    if (revents & POLLNVAL) {
+        Logger::logFrom(LogLevel::ERROR, "SocketManager",
+                        "Invalid poll event on fd: " + std::to_string(fd));
+    }
+    else if (revents & POLLERR) {
         Logger::logFrom(LogLevel::ERROR, "SocketManager",
                         "Socket error on fd: " + std::to_string(fd));
-    if (revents & POLLHUP)
+    }
+    else if (revents & POLLHUP) {
         Logger::logFrom(LogLevel::INFO, "SocketManager",
                         "Client disconnected (POLLHUP) on fd: " + std::to_string(fd));
+ }
     cleanupClientConnectionClose(fd, index);
 }
 
@@ -420,7 +426,7 @@ void SocketManager::run() {
             }
 
             // Now error/hangup on *client* sockets
-            if (revents & POLLERR || revents & POLLHUP) {
+            if (revents & POLLERR || revents & POLLHUP || revents & POLLNVAL) {
                 handlePollError(current_fd, i, revents);
                 continue;
             }
@@ -449,6 +455,12 @@ void SocketManager::run() {
 void SocketManager::handleNewConnection(int listen_fd) {
     int client_fd = accept(listen_fd, NULL, NULL);
     if (client_fd < 0) {
+        if (errno == EMFILE || errno == ENFILE) {
+            // We’ve hit the per‐process or system FD limit.
+            Logger::logFrom(LogLevel::ERROR, "SocketManager",
+                            "Out of file descriptors (accept failed: " + std::string(strerror(errno)) + ")");
+            return;
+        }
         Logger::logFrom(LogLevel::ERROR, "SocketManager",
                         "accept() failed: " + std::string(std::strerror(errno)));
         return;

--- a/src/utils/filesystemUtils.cpp
+++ b/src/utils/filesystemUtils.cpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   filesystemUtils.cpp                                :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: nlouis <nlouis@student.hive.fi>            +#+  +:+       +#+        */
+/*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/13 09:39:07 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/03 21:09:08 by nlouis           ###   ########.fr       */
+/*   Updated: 2025/06/06 12:43:26 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -316,6 +316,12 @@ std::string decodePercentEncoding(const std::string& encoded) {
 
 bool isSymlink(const std::string& path) {
     return fs::is_symlink(fs::path(path));
+}
+
+time_t getCurrentTime() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch()
+           ).count();
 }
 
 /* std::string normalizePath(const std::string& path) {

--- a/src/utils/filesystemUtils.cpp
+++ b/src/utils/filesystemUtils.cpp
@@ -6,23 +6,30 @@
 /*   By: irychkov <irychkov@student.hive.fi>        +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/13 09:39:07 by nlouis            #+#    #+#             */
-/*   Updated: 2025/06/06 12:43:26 by irychkov         ###   ########.fr       */
+/*   Updated: 2025/06/06 13:37:27 by irychkov         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "utils/filesystemUtils.hpp"
-#include "http/HttpResponseBuilder.hpp"
-
-#include <algorithm>
-#include <chrono>
-#include <filesystem>
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <map>
-#include <regex>
-#include <sstream>
-#include <string>
+#include "core/Location.hpp"            // for Location
+#include "core/Server.hpp"              // for Server
+#include "http/HttpRequest.hpp"         // for HttpRequest
+#include "http/HttpResponseBuilder.hpp" // for generateError, generateSuccess
+#include <algorithm>                    // for transform
+#include <chrono>                       // for duration_cast, duration, hig...
+#include <cstring>                      // for size_t, strerror
+#include <ctype.h>                      // for isxdigit, tolower
+#include <errno.h>                      // for errno, EEXIST
+#include <filesystem>                   // for path, exists, is_regular_file
+#include <fstream>                      // for basic_ifstream, basic_filebuf
+#include <iostream>                     // for basic_ostream, operator<<
+#include <map>                          // for map, operator==, _Rb_tree_co...
+#include <sstream>                      // for basic_ostringstream, basic_i...
+#include <stdexcept>                    // for invalid_argument
+#include <string>                       // for char_traits, allocator, string
+#include <sys/stat.h>                   // for mkdir
+#include <utility>                      // for pair
+#include <vector>                       // for vector
 
 namespace fs = std::filesystem;
 
@@ -320,8 +327,8 @@ bool isSymlink(const std::string& path) {
 
 time_t getCurrentTime() {
     return std::chrono::duration_cast<std::chrono::seconds>(
-               std::chrono::system_clock::now().time_since_epoch()
-           ).count();
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
 }
 
 /* std::string normalizePath(const std::string& path) {

--- a/test/config/iurii_Hive_basic.conf
+++ b/test/config/iurii_Hive_basic.conf
@@ -1,0 +1,75 @@
+server {
+	host 127.0.0.1;
+	listen 8080;
+	server_name test-get;
+
+	error_page 403 /error_403.html;
+	error_page 404 /error_404.html;
+	client_max_body_size 1M;
+
+	location / {
+		root /home/irychkov/Desktop/webserv_team/test/data;
+		methods GET DELETE;
+		index index.html;
+		autoindex on;
+	}
+
+	location /dir {
+		root /home/irychkov/Desktop/webserv_team/test/data/dir;
+		methods GET DELETE;
+		autoindex on;
+	}
+
+	location /forbidden/ {
+		root /home/irychkov/Desktop/webserv_team/test/data/secret;
+		methods GET;
+		autoindex off;
+		index index.html;
+	}
+
+	location /upload_store/ {
+		root /home/irychkov/Desktop/webserv_team/test/data;
+		methods GET POST DELETE;
+		upload_store /home/irychkov/Desktop/webserv_team/test/data/upload_store;
+		autoindex on;
+	}
+
+	location /with_index/ {
+		root /home/irychkov/Desktop/webserv_team/test/data/with_index;
+		methods GET DELETE;
+		autoindex on;
+		index index.html;
+	}
+
+	location /cgi-bin {
+		root /home/irychkov/Desktop/webserv_team/test/data/cgi-bin;
+		methods GET POST;
+		cgi_extension .py, .sh;
+		cgi_interpreter .py /usr/bin/python3;
+		cgi_interpreter .sh /bin/bash;
+		autoindex off;
+	}
+}
+
+server {
+	host 127.0.0.1;
+	listen 8081;
+	server_name test-upload;
+
+	error_page 403 /error_403.html;
+	error_page 404 /error_404.html;
+	client_max_body_size 2M;
+
+	location /upload_store/ {
+		root /home/irychkov/Desktop/webserv_team/test/data;
+		methods GET POST DELETE;
+		upload_store /home/irychkov/Desktop/webserv_team/test/data/upload_store_alt;
+	}
+
+	location / {
+		root /home/irychkov/Desktop/webserv_team/test/data/upload_alt_root;
+		methods GET;
+		autoindex on;
+		index index.html;
+	}
+}


### PR DESCRIPTION
## 📋 Title Format

```bash
socket: handle EMFILE during accept and cgi refactoring)
```

---

## 📄 Description

### 🔧 What does this PR change?

- Adds explicit handling for `EMFILE` error in the `accept()` system call to improve robustness under file descriptor exhaustion.
- Refactors CGI handling code (`handleCgi`) for better readability and maintainability.
- Introduces a helper function `unlinkWithErrorLog` for consistent and centralized error logging when removing temporary files.
- Ensures correct error response is set for CGI execution failures.
- Adds logging for `waitpid` failure to aid debugging.
- Refactors includes and removes unused dependencies.
- Adds `getCurrentTime()` helper to replace disallowed use of `time()` in the project context.

### 🧠 Why is this change necessary?

- Prevents the server from crashing or hanging when the process reaches the file descriptor limit.
- Improves code maintainability and error traceability in CGI processing.
- Helps maintain compliance with Webserv project requirements and the principle that the server must remain resilient under all circumstances.

### 👀 Anything special to watch for during review?

- Confirm EMFILE handling logic doesn’t lead to infinite loops or dropped clients.
- Review the logic in `unlinkWithErrorLog()` to ensure it's only used where cleanup is required.
- Validate that all places that used `unlink()` directly for CGI now use the centralized helper.

---

## ✅ Checklist Before Review

- [x] My branch is up to date with `dev` (`git fetch && git rebase dev`).
- [x] I followed the [Commit Message Guidelines](../CONTRIBUTING.md#-commit-guidelines).
- [x] Code builds and runs without errors (`make && ./webserv`).
- [x] I manually tested this change (curl, browser, scripts).
- [x] I stress-tested this feature (multi-connection, upload size, etc.).
- [x] There are no debug prints or commented-out code left.
- [x] Memory check passed (`valgrind` or `-fsanitize=address` if available).

---

## 🧪 How I Tested

```text
- Simulated EMFILE by setting RLIMIT_NOFILE to low values and verifying error log + server recovery.
- Ran 100+ concurrent CGI requests with varying payloads to validate refactored `handleCgi` logic.
- Verified temporary file cleanup by inspecting `/tmp` and checking for leaked files.
- Confirmed `waitpid` logging on zombie processes using forced fork/exit in CGI.
```

